### PR TITLE
Time based schedules

### DIFF
--- a/ControlStrategyScheduler.cpp
+++ b/ControlStrategyScheduler.cpp
@@ -22,7 +22,7 @@ StrategySchedule ControlStrategyScheduler::getActiveSchedule(SimpleTime currentT
   }
 
 //Otherwise, return the latest schedule whose activationTime has passed
-  uint8_t activeScheduleIdx;
+  uint8_t activeScheduleIdx = lastIdx;
   for (int i = 0; i < this->strategyCount; i++) {
     if (this->strategySchedules[i].activationTime <= currentTime) {
       activeScheduleIdx = i;

--- a/ControlStrategyScheduler.cpp
+++ b/ControlStrategyScheduler.cpp
@@ -9,26 +9,31 @@ void ControlStrategyScheduler::printNewStrategyMessage() {
 }
 
 StrategySchedule ControlStrategyScheduler::getActiveSchedule(SimpleTime currentTime) {
+  const uint8_t lastIdx = this->strategyCount - 1;
+  uint8_t activeScheduleIdx;
+
 // Special case of single schedule
-  if (this->strategyCount == 1) {
-    return this->strategySchedules[0];
-  }
-
-//  Special case of latest schedule active and time rolled over past midnight
-  uint8_t lastIdx = this->strategyCount - 1;
-  if (this->lastActiveStrategyIdx == lastIdx
-      && currentTime < this->strategySchedules[0].activationTime) {
-    return this->strategySchedules[lastIdx];      
-  }
-
-//Otherwise, return the latest schedule whose activationTime has passed
-  uint8_t activeScheduleIdx = lastIdx;
-  for (int i = 0; i < this->strategyCount; i++) {
-    if (this->strategySchedules[i].activationTime <= currentTime) {
-      activeScheduleIdx = i;
+ if (this->strategyCount == 0) {
+  activeScheduleIdx = lastIdx;
+ }
+  
+//  Special case of latest or earliest schedule active and time rolled over past midnight
+  else if ((this->lastActiveStrategyIdx == lastIdx || this->lastActiveStrategyIdx == 0)
+      && currentTime < this->strategySchedules[0].activationTime) { 
+    activeScheduleIdx = lastIdx;  
+  } 
+  
+//Otherwise, return the latest schedule whose activationTime has passed  
+  else {
+    activeScheduleIdx = lastIdx;
+    for (int i = 0; i < this->strategyCount; i++) {
+      if (this->strategySchedules[i].activationTime <= currentTime) {
+        activeScheduleIdx = i;
+      }
     }
   }
 
+  
   if (activeScheduleIdx != this->lastActiveStrategyIdx) {
     this->lastActiveStrategyIdx = activeScheduleIdx;
     this->printNewStrategyMessage();
@@ -46,7 +51,12 @@ void ControlStrategyScheduler::appendStrategyToSchedule(ControlStrategy* strateg
     Serial.print("Added new strategy to schedule: ");
     Serial.println(strategy->getName());
   } else {
-    Serial.println("Failed to add stratedy to scheduler: Max strategy count exceeded.");
+    Serial.println("Failed to add strategy to scheduler: Max strategy count exceeded.");
+  }
+
+  if (this->strategyCount == 1) {
+    Serial.print("Controller will start up using strategy: ");
+    Serial.println(strategy->getName());
   }
 }
 

--- a/ControlStrategyScheduler.h
+++ b/ControlStrategyScheduler.h
@@ -2,22 +2,19 @@
 #define CONTROLSTRATEGYSCHEDULER
 
 #include "StrategySchedule.h"
+#include "SimpleTime.h"
 
 class ControlStrategyScheduler {
   static const uint8_t MAX_STRATEGY_COUNT = 32;
   StrategySchedule strategySchedules[MAX_STRATEGY_COUNT];
   uint8_t strategyCount = 0;
-  uint8_t activeStrategyIdx = 0;
+  uint8_t lastActiveStrategyIdx = 0;
   
-  unsigned long int lastStrategyChange = 0;
-  unsigned long int nextStrategyChange = 0;
-  
-  void incrementActiveSchedule();
   void printNewStrategyMessage();
-  StrategySchedule getActiveSchedule();
+  StrategySchedule getActiveSchedule(SimpleTime currentTime);
 
   public:
-  void appendStrategyToSchedule(ControlStrategy* strategy, unsigned long int duration);
+  void appendStrategyToSchedule(ControlStrategy* strategy, SimpleTime activationTime);
   ControlStrategy* getActiveStrategy();
   void printSchedule();
 

--- a/OutputDeviceController.cpp
+++ b/OutputDeviceController.cpp
@@ -8,8 +8,8 @@ void OutputDeviceController::printControlValue() {
   Serial.println(this->latestControlValue);
 }
 
-void OutputDeviceController::appendStrategy(ControlStrategy* newStrategy, unsigned long int duration) {
-  this->scheduler.appendStrategyToSchedule(newStrategy, duration);
+void OutputDeviceController::appendStrategy(ControlStrategy* newStrategy, SimpleTime activationTime) {
+  this->scheduler.appendStrategyToSchedule(newStrategy, activationTime);
   this->proc();
 }
 
@@ -30,7 +30,7 @@ void OutputDeviceController::proc() {
   this->device.setOutput(this->latestControlValue);
   
   if (this->latestControlValue != previousControlValue) {
-    this->printControlValue();
+//    this->printControlValue();
   }
   
 }

--- a/OutputDeviceController.h
+++ b/OutputDeviceController.h
@@ -4,6 +4,7 @@
 #include "OutputDevice.h"
 #include "ControlStrategy.h"
 #include "ControlStrategyScheduler.h"
+#include "SimpleTime.h"
 
 class OutputDeviceController {
   OutputDevice device;
@@ -14,7 +15,7 @@ class OutputDeviceController {
   void printControlValue();
 
   public:
-  void appendStrategy(ControlStrategy* newStrategy, unsigned long int duration);
+  void appendStrategy(ControlStrategy* newStrategy, SimpleTime activationTime);
   void proc();
   void enable();
   void disable(int manualValue);

--- a/StrategySchedule.cpp
+++ b/StrategySchedule.cpp
@@ -1,5 +1,5 @@
 #include "StrategySchedule.h"
 
-StrategySchedule::StrategySchedule(ControlStrategy* strategy, unsigned long int duration): strategy(strategy), duration(duration) {}
+StrategySchedule::StrategySchedule(ControlStrategy* strategy, SimpleTime activationTime): strategy(strategy), activationTime(activationTime) {}
 
-StrategySchedule::StrategySchedule(): StrategySchedule(nullptr, 0) {}
+StrategySchedule::StrategySchedule(): StrategySchedule(nullptr, SimpleTime(0,0,0)) {}

--- a/StrategySchedule.h
+++ b/StrategySchedule.h
@@ -2,12 +2,13 @@
 #define STRATEGYSCHEDULE
 
 #include "ControlStrategy.h"
+#include "SimpleTime.h"
 
 struct StrategySchedule {
   ControlStrategy* strategy;
-  unsigned long int duration;
+  SimpleTime activationTime;
 
-  StrategySchedule(ControlStrategy* strategy, unsigned long int duration);
+  StrategySchedule(ControlStrategy* strategy, SimpleTime activationTime);
   StrategySchedule();
 };
 

--- a/geckfog.ino
+++ b/geckfog.ino
@@ -60,14 +60,11 @@ void setup() {
     Serial.println("Connected!");
 
   humidifierController.appendStrategy(&offStrategy, SimpleTime(6,0,0)); //6am-9am
-  humidifierController.appendStrategy(&humidityMaintenanceStrategy, SimpleTime(9,0,0)); //9am-12pm
-  humidifierController.appendStrategy(&humidityMaintenanceStrategy, SimpleTime(12,0,0)); //12pm-8pm
+  humidifierController.appendStrategy(&humidityMaintenanceStrategy, SimpleTime(9,0,0)); //9am-8pm
   humidifierController.appendStrategy(&heavyDewmakerStrategy, SimpleTime(20,0,0)); //8pm-10pm
   humidifierController.appendStrategy(&dewmakerStrategy, SimpleTime(22,0,0)); //10pm-6am
   
 //  misterController.appendStrategy(&mistingStrategy, 1000*60*60*24);
-
-  
 
   humidifier.init();
   mister.init();

--- a/geckfog.ino
+++ b/geckfog.ino
@@ -37,6 +37,7 @@ DutyCycleStrategy dewmakerStrategy = DutyCycleStrategy(5000, 20000);
 DutyCycleStrategy humidityMaintenanceStrategy = DutyCycleStrategy(8000, 1000*60*15); //up from 5000 on
 
 DutyCycleStrategy mistingStrategy = DutyCycleStrategy(5000, 1000*10);
+DutyCycleStrategy flipFlop = DutyCycleStrategy(15000, 15000);
 
 ConstantValueControlStrategy onStrategy = ConstantValueControlStrategy(255);
 ConstantValueControlStrategy offStrategy = ConstantValueControlStrategy(0);
@@ -59,12 +60,13 @@ void setup() {
     }
     Serial.println("Connected!");
 
-  // noon start
-  humidifierController.appendStrategy(&humidityMaintenanceStrategy, 1000*60*60*8); //12pm-8pm
-  humidifierController.appendStrategy(&heavyDewmakerStrategy, 1000*60*60*2); //8pm-10pm
-  humidifierController.appendStrategy(&dewmakerStrategy, 1000*60*60*8); //10pm-6am
-  humidifierController.appendStrategy(&offStrategy, 1000*60*60*3); //6am-9am
-  humidifierController.appendStrategy(&humidityMaintenanceStrategy, 1000*60*60*3); //9am-12pm
+  
+  humidifierController.appendStrategy(&offStrategy, SimpleTime(6,0,0)); //6am-9am
+  humidifierController.appendStrategy(&humidityMaintenanceStrategy, SimpleTime(9,0,0)); //9am-12pm
+  humidifierController.appendStrategy(&humidityMaintenanceStrategy, SimpleTime(12,0,0)); //12pm-8pm
+  humidifierController.appendStrategy(&heavyDewmakerStrategy, SimpleTime(20,0,0)); //8pm-10pm
+  humidifierController.appendStrategy(&dewmakerStrategy, SimpleTime(22,0,0)); //10pm-6am
+  
 //  misterController.appendStrategy(&mistingStrategy, 1000*60*60*24);
 
   
@@ -77,7 +79,6 @@ void setup() {
 
 
 void loop() {
-  InternetTime::getSimpleTime();
   humidifierController.proc();
   misterController.proc();
 }

--- a/geckfog.ino
+++ b/geckfog.ino
@@ -37,7 +37,6 @@ DutyCycleStrategy dewmakerStrategy = DutyCycleStrategy(5000, 20000);
 DutyCycleStrategy humidityMaintenanceStrategy = DutyCycleStrategy(8000, 1000*60*15); //up from 5000 on
 
 DutyCycleStrategy mistingStrategy = DutyCycleStrategy(5000, 1000*10);
-DutyCycleStrategy flipFlop = DutyCycleStrategy(15000, 15000);
 
 ConstantValueControlStrategy onStrategy = ConstantValueControlStrategy(255);
 ConstantValueControlStrategy offStrategy = ConstantValueControlStrategy(0);
@@ -60,7 +59,6 @@ void setup() {
     }
     Serial.println("Connected!");
 
-  
   humidifierController.appendStrategy(&offStrategy, SimpleTime(6,0,0)); //6am-9am
   humidifierController.appendStrategy(&humidityMaintenanceStrategy, SimpleTime(9,0,0)); //9am-12pm
   humidifierController.appendStrategy(&humidityMaintenanceStrategy, SimpleTime(12,0,0)); //12pm-8pm


### PR DESCRIPTION
Added schedules based on time-server synchronisation rather than dumb duration.
Currently pings the time server every time, which is undesirable, so implementation of an hybrid clock (using occasional internet time and millis()) will be necessary.